### PR TITLE
Support shared sessions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,6 +73,7 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+      - run: julia -e "import Pkg; Pkg.add(\"TestEnv\")"
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,7 +73,6 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-      - run: julia -e "import Pkg; Pkg.add(\"TestEnv\")"
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -83,7 +83,6 @@ jobs:
           version: '1.6'
       - run: julia --project=docs -e '
           using Pkg;
-          Pkg.develop(PackageSpec(; path=pwd()));
           Pkg.instantiate();'
       - run: julia --project=docs docs/make.jl
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /Manifest.toml
+docs/build/

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 ReplMaker = "b873ce64-0db9-51f5-a568-4457d8e49576"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 OpenSSH_jll = "8.1, 9"

--- a/bin/julia-r
+++ b/bin/julia-r
@@ -19,7 +19,7 @@ atreplinit() do repl
         # Run one command as part of connection setup to trigger compilation
         # This makes the REPL more immediately responsive after it prints the
         # welcome message.
-        RemoteREPL.run_remote_repl_command(RemoteREPL._repl_client_connection,
+        remotecmd(RemoteREPL._repl_client_connection,
                                            stdout, "\"hi\"")
         println("""
             Connected to $host

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,5 +1,17 @@
 # This file is machine-generated - editing it directly is not advised
 
+[[ANSIColoredPrinters]]
+git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"
+uuid = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"
+version = "0.0.1"
+
+[[ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.1"
+
+[[Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
@@ -9,35 +21,67 @@ uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
 [[DocStringExtensions]]
 deps = ["LibGit2"]
-git-tree-sha1 = "a32185f5428d3986f47c2ab78b1f216d5e6cc96f"
+git-tree-sha1 = "2fb1e02f2b635d0845df5d7c167fec4dd739b00d"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.8.5"
+version = "0.9.3"
 
 [[Documenter]]
-deps = ["Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
-git-tree-sha1 = "621850838b3e74dd6dd047b5432d2e976877104e"
+deps = ["ANSIColoredPrinters", "Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
+git-tree-sha1 = "58fea7c536acd71f3eef6be3b21c0df5f3df88fd"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.27.2"
+version = "0.27.24"
+
+[[Downloads]]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.6.0"
+
+[[FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[IOCapture]]
 deps = ["Logging", "Random"]
-git-tree-sha1 = "f7be53659ab06ddc986428d3a9dcc95f6fa6705a"
+git-tree-sha1 = "d75853a0bdbfb1ac815478bacd89cd27b550ace6"
 uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
-version = "0.2.2"
+version = "0.2.3"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
+[[JLLWrappers]]
+deps = ["Preferences"]
+git-tree-sha1 = "abc9885a7ca2052a736a600f7fa66209f96506e1"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.4.1"
+
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
+git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.1"
+version = "0.21.4"
+
+[[LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.3"
+
+[[LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "7.84.0+0"
 
 [[LibGit2]]
 deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.10.2+0"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -46,17 +90,56 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
+[[MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.28.2+0"
+
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
+[[MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2022.10.11"
+
 [[NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.2.0"
+
+[[OpenSSH_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "OpenSSL_jll", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "1b2f042897343a9dfdcc9366e4ecbd3d00780c49"
+uuid = "9bd350c2-7e96-507f-8002-3f2e150b4e1b"
+version = "8.9.0+1"
+
+[[OpenSSL_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "1aa4b74f80b01c6bc2b89992b861b5f210e665b5"
+uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
+version = "1.1.21+0"
 
 [[Parsers]]
-deps = ["Dates"]
-git-tree-sha1 = "c8abc88faa3f7a3950832ac5d6e690881590d6dc"
+deps = ["Dates", "PrecompileTools", "UUIDs"]
+git-tree-sha1 = "4b2e829ee66d4218e0cef22c0a64ee37cf258c29"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.1.0"
+version = "2.7.1"
+
+[[Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.9.0"
+
+[[PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "9673d39decc5feece56ef3940e5dafba15ba0f81"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.1.2"
+
+[[Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "7eb1686b4f04b82f96ed7a4ea5890a4f0c7a09f1"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.4.0"
 
 [[Printf]]
 deps = ["Unicode"]
@@ -67,11 +150,24 @@ deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[Random]]
-deps = ["Serialization"]
+deps = ["SHA", "Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[RemoteREPL]]
+deps = ["Logging", "OpenSSH_jll", "REPL", "ReplMaker", "Serialization", "Sockets", "UUIDs"]
+path = ".."
+uuid = "1bd9f7bb-701c-4338-bec7-ac987af7c555"
+version = "0.2.17"
+
+[[ReplMaker]]
+deps = ["REPL", "Unicode"]
+git-tree-sha1 = "f8bb680b97ee232c4c6591e213adc9c1e4ba0349"
+uuid = "b873ce64-0db9-51f5-a568-4457d8e49576"
+version = "0.2.7"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
 
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
@@ -79,9 +175,38 @@ uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
+[[TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
+
 [[Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.2.13+0"
+
+[[nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.48.0+0"
+
+[[p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.4.0+0"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,2 +1,3 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+RemoteREPL = "1bd9f7bb-701c-4338-bec7-ac987af7c555"

--- a/docs/src/howto.md
+++ b/docs/src/howto.md
@@ -118,6 +118,15 @@ julia> session_id = UUID("f03aec15-3e14-4d58-bcfa-82f8d33c9f9a")
 julia> connect_repl(; session_id=session_id)
 ```
 
+## Pass a command non-interactively
+To programmatically pass a command to the remote julia kernel use [`remotecmd`](@ref). For example:
+
+```julia
+julia> con2server = connect_remote(Sockets.localhost, 9093) # connect to port 9093 in localhost
+
+julia> remotecmd(con2server, "myvar = 1") # define a new var
+```
+
 ## Use alternatives to SSH
 
 ### AWS Session Manager

--- a/docs/src/howto.md
+++ b/docs/src/howto.md
@@ -107,6 +107,17 @@ julia@localhost> a_variable
 1
 ```
 
+
+## Use common session among different clients
+A session, as implemented in `ServerSideSession`, describes the display properties and the module under which commands are evaluated.
+Multiple clients can share same such properties by using the same `session_id`. For example:
+
+```julia
+julia> session_id = UUID("f03aec15-3e14-4d58-bcfa-82f8d33c9f9a")
+
+julia> connect_repl(; session_id=session_id)
+```
+
 ## Use alternatives to SSH
 
 ### AWS Session Manager
@@ -127,6 +138,53 @@ In environments without any REPL integrations like Jupyter or Pluto notebooks yo
 connect_remote();
 ```
 which will allow you to use `@remote` without the REPL mode.
+
+### More on Pluto
+Pluto presents a peculiarity as the default module is constantly changing.
+In order to closely track the newest notebook state, you will need to tap into the client's session and update the module.
+You could write the following code in the pluto notebook that updates the module every second (if you have a better event-driven update solution, please raise an issue!).
+
+```julia
+using PlutoLinks, PlutoHooks
+
+using RemoteREPL, Sockets, UUIDs
+
+server = Sockets.listen(Sockets.localhost, 27765)
+
+@async serve_repl(server)
+
+session_id = UUID("f03aec15-3e14-4d58-bcfa-82f8d33c9f9a")
+
+con2server = connect_remote(Sockets.localhost, 27765; session_id=session_id)
+
+takemodulesymbol() = Symbol("workspace#" ,PlutoRunner.moduleworkspace_count[])
+
+let # update module in RemoteREPL every 1 sec
+	count, set_count = @use_state(1)
+	@use_task([]) do
+		new_count = count
+		while true
+			sleep(1.0)
+			new_count += 1
+			set_count(new_count) # (this will trigger a re-run)
+		end
+	end
+	mod = eval(takemodulesymbol())
+	#@eval(@remoterepl $"%module $mod")
+	remote_module!(mod)
+end
+```
+
+Then open a repl and do:
+
+```julia
+julia> using RemoteREPL, Sockets, UUIDs
+
+julia> connect_repl(Sockets.localhost, 27765; session_id=UUID("f03aec15-3e14-4d58-bcfa-82f8d33c9f9a"))
+```
+
+Since the session's module is being regularly updated by the Pluto notebook, your REPL will be in sync with the notebook's state.
+
 
 ## Troubleshooting connection issues 
 Sometimes errors will be encountered. This section aims to show some errors experienced by users, and what the underlying problem was. We will use some terms in this section, introduced in the table below.
@@ -153,3 +211,4 @@ any group or other users. On a linux system, this is accomplished by running the
 chmod go-w /home/username/.ssh/*
 ```
 If you are using a different operating system, please google how to remove write permissions on files, and try to do the same thing.
+

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -42,5 +42,7 @@ serve_repl
 connect_remote
 RemoteREPL.@remote
 RemoteREPL.remote_eval
+RemoteREPL.run_remote_repl_command
+RemoteREPL.remote_module!
 ```
 

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -42,7 +42,7 @@ serve_repl
 connect_remote
 RemoteREPL.@remote
 RemoteREPL.remote_eval
-RemoteREPL.run_remote_repl_command
+RemoteREPL.remotecmd
 RemoteREPL.remote_module!
 ```
 

--- a/src/RemoteREPL.jl
+++ b/src/RemoteREPL.jl
@@ -5,7 +5,7 @@ using Sockets, Serialization
 using UUIDs, Logging
 using OpenSSH_jll
 
-export connect_repl, serve_repl, @remote, connect_remote, run_remote_repl_command, remote_module!
+export connect_repl, serve_repl, @remote, connect_remote, remotecmd, remote_module!
 
 const DEFAULT_PORT = 27754
 const PROTOCOL_MAGIC = "RemoteREPL"

--- a/src/RemoteREPL.jl
+++ b/src/RemoteREPL.jl
@@ -9,7 +9,7 @@ export connect_repl, serve_repl, @remote, connect_remote, remotecmd, remote_modu
 
 const DEFAULT_PORT = 27754
 const PROTOCOL_MAGIC = "RemoteREPL"
-const PROTOCOL_VERSION = UInt32(1)
+const PROTOCOL_VERSION = UInt32(2)
 
 const STDOUT_PLACEHOLDER = Symbol("#RemoteREPL_STDOUT_PLACEHOLDER")
 

--- a/src/RemoteREPL.jl
+++ b/src/RemoteREPL.jl
@@ -1,6 +1,11 @@
 module RemoteREPL
 
-export connect_repl, serve_repl, @remote, connect_remote
+using REPL, ReplMaker
+using Sockets, Serialization
+using UUIDs, Logging
+using OpenSSH_jll
+
+export connect_repl, serve_repl, @remote, connect_remote, run_remote_repl_command, remote_module!
 
 const DEFAULT_PORT = 27754
 const PROTOCOL_MAGIC = "RemoteREPL"

--- a/src/client.jl
+++ b/src/client.jl
@@ -139,10 +139,10 @@ function setup_connection!(conn::Connection)
             namespace=conn.namespace)
     end
     Sockets.nagle(socket, false)  # Disables nagles algorithm. Appropriate for interactive connections.
-    # transmit session id
-    serialize(socket, conn.session_id)
     try
         verify_header(socket)
+        # transmit session id
+        serialize(socket, conn.session_id)
     catch exc
         close(socket)
         rethrow()

--- a/src/server.jl
+++ b/src/server.jl
@@ -177,7 +177,6 @@ end
 
 # Serve a remote REPL session to a single client
 function serve_repl_session(session, socket)
-    send_header(socket)
     @sync begin
         request_chan = Channel(1)
         response_chan = Channel(1)
@@ -252,6 +251,8 @@ function serve_repl(server::Base.IOServer; on_client_connect=nothing)
         while isopen(server)
             socket = accept(server)
 
+            # send magic
+            send_header(socket)
             # expect session id
             session_id = deserialize(socket)
             session = lock(session_lock) do

--- a/src/server.jl
+++ b/src/server.jl
@@ -252,16 +252,15 @@ function serve_repl(server::Base.IOServer; on_client_connect=nothing)
         while isopen(server)
             socket = accept(server)
 
-            session, session_id, socketidx = lock(session_lock) do
-                # expect session id
-                session_id = deserialize(socket)
-                session = if haskey(open_sessions, session_id)
+            # expect session id
+            session_id = deserialize(socket)
+            session = lock(session_lock) do
+                if haskey(open_sessions, session_id)
                     push!(open_sessions[session_id].sockets, socket)
                     open_sessions[session_id] 
                 else
                     open_sessions[session_id] = ServerSideSession([socket], Dict(), Main) 
                 end
-                session, session_id, length(session.sockets)
             end
 
             peer = getpeername(socket)

--- a/src/tunnels.jl
+++ b/src/tunnels.jl
@@ -1,7 +1,5 @@
 # Utilities for securely tunnelling traffic from client to a remote server
 
-using OpenSSH_jll
-
 # Find a free port on `network_interface`
 function find_free_port(network_interface)
     # listen on port 0 => kernel chooses a free port. See, for example,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using RemoteREPL
 using Test
 using Sockets
 using RemoteREPL: repl_prompt_text, match_magic_syntax, DEFAULT_PORT
+using UUIDs
 
 ENV["JULIA_DEBUG"] = "RemoteREPL"
 
@@ -52,7 +53,7 @@ end
     function fake_conn(host, port; is_open=true)
         io = IOBuffer()
         is_open || close(io)
-        RemoteREPL.Connection(host, port, :none, ``, nothing, nothing, io, :Main)
+        RemoteREPL.Connection(host, port, :none, ``, nothing, nothing, io, :Main, uuid4())
     end
     @test repl_prompt_text(fake_conn(Sockets.localhost, DEFAULT_PORT)) == "julia@localhost> "
     @test repl_prompt_text(fake_conn("localhost",       DEFAULT_PORT)) == "julia@localhost> "

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -114,7 +114,7 @@ end
 
 # Use non-default port to avoid clashes with concurrent interactive use or testing.
 test_port = RemoteREPL.find_free_port(Sockets.localhost)
-server_proc = run(`$(Base.julia_cmd()) --project -e "using TestEnv; TestEnv.activate(); using RemoteREPL, Sockets, UUIDs ; serve_repl($test_port)"`, wait=false)
+server_proc = run(`$(Base.julia_cmd()) --project -e "using RemoteREPL, Sockets, UUIDs ; serve_repl($test_port)"`, wait=false)
 
 try
 
@@ -302,7 +302,7 @@ end
 
 
 test_port = RemoteREPL.find_free_port(Sockets.localhost)
-server_proc = run(```$(Base.julia_cmd()) --project -e "using TestEnv; TestEnv.activate(); using RemoteREPL, Sockets, UUIDs ; module EvalInMod ; end;
+server_proc = run(```$(Base.julia_cmd()) --project -e "using RemoteREPL, Sockets, UUIDs ; module EvalInMod ; end;
                   serve_repl($test_port, on_client_connect=sess->sess.in_module=EvalInMod)"```, wait=false)
 try
 
@@ -328,3 +328,5 @@ end
 finally
     kill(server_proc)
 end
+
+nothing


### PR DESCRIPTION
Redesign for https://github.com/c42f/RemoteREPL.jl/pull/45

# Novelties and summary
In #45 we discussed that it would be better to use the underlying protocol to change the module.
It became clear that this is easier done if shared sessions were supported.
So instead of directly solving my problem I tried to introduce multiple shared sessions.
As a result, module update for Pluto is now also more straightforward.

#### 1. `session_id`
Basically I introduced a `session_id` that characterizes every `ServerSideSession`.
The server holds all the sessions in a `Dict{UUID, ServerSideSession}`.
Everytime a client connects, it send the session UUID it wants to connect to as the first thing.

#### 2. `SessionSideSession`
Now `SessionSideSession` is not described by a single `Socket` but a vector of `Socket`s, which is kept up to date.

#### 3. `@remoterepl`
I need a way to still connect remotely and change the module, i.e. `%module ...`, without having a REPL available (like Pluto).
`@remote` support only command execution. Therefore I introduced `@remoterepl` which gives access to the REPL magic commands for all clients.
The question is.. why not collapse `@remote` to `@remoterepl`, since the second is a superset ?

#### 4. Structural changes
I put all the `using` dependencies on the src/RemoteREPL.jl file. 
I find it much more readable this way and it also follows community conventions.

### Pluto side
Pluto notebook should look something like [this gist](https://gist.github.com/filchristou/80ab232ca1be67fb59de689913f41785).
I am not sure how to avoid the updating every second, but don't focus on that; this is a Pluto issue/discussion.
Basically Pluto just uses `@remoterepl` to upgrade the module in a specific session.
The core code boils down to
```julia
server = Sockets.listen(Sockets.localhost, 27765)

@async serve_repl(server)

session_id = UUID("f03aec15-3e14-4d58-bcfa-82f8d33c9f9a")

con2server = connect_remote(Sockets.localhost, 27765; session_id=session_id)

# define function to get more recent module
takemodulesymbol() = Symbol("workspace#" ,PlutoRunner.moduleworkspace_count[])

# get module
mod = eval(takemodulesymbol())

# use `@remoterepl` to update module
@eval(@remoterepl $"%module $mod")
```

### Test
Run the pluto notebook.
Open a julia kernel, add dependencies and do:
```julia
julia> using RemoteREPL, Sockets, UUIDs

julia> connect_repl(Sockets.localhost, 27765; session_id=UUID("f03aec15-3e14-4d58-bcfa-82f8d33c9f9a"))
[ Info: Using session id f03aec15-3e14-4d58-bcfa-82f8d33c9f9a
REPL mode remote_repl initialized. Press > to enter and backspace to exit.
"Prompt(\"julia@localhost:27765> \",...)"

julia@localhost:27765> temp
1

julia@localhost:27765> @__MODULE__
Main.var"workspace#1261"

julia@localhost:27765> @__MODULE__
Main.var"workspace#1265"

julia> # uncomment "# anewvar = 2"

julia> @remote(anewvar)
2
```
As you can see the remote client closely follows the changes in the Pluto notebook.

Let me know how that looks and I am happy to hear your thoughts!