### PR TITLE
fix tab completion for Julia 1.11

### DIFF
--- a/src/client.jl
+++ b/src/client.jl
@@ -278,7 +278,8 @@ function path_str(path_completion)
 end
 
 function REPL.complete_line(provider::RemoteCompletionProvider,
-                            state::REPL.LineEdit.PromptState)::
+                            state::REPL.LineEdit.PromptState;
+                            hint::Bool=false)::
                             Tuple{Vector{String},String,Bool}
     # See REPL.jl complete_line(c::REPLCompletionProvider, s::PromptState)
     partial = REPL.beforecursor(state.input_buffer)


### PR DESCRIPTION
Currently line completion is not working with Julia 1.11 due to additional keyword arg `hint` in `complete_line()`.
Adding the keyword with a default value fixes the problem. The keyword doesn't have any function except matching the dispatch call.